### PR TITLE
Sundry text changes, take two

### DIFF
--- a/help/en-gb/admin/remember_login.textile
+++ b/help/en-gb/admin/remember_login.textile
@@ -1,5 +1,5 @@
 h1. Remember login
 
-When checked, you will remain logged in to your Textpattern account with the current web browser, until you choose to logout. If left unchecked, you will be automatically logged out after a period of inactivity.
+When checked, you will remain logged in to your Textpattern account with the current web browser, until you choose to log out. If left unchecked, you will be automatically logged out after a period of inactivity.
 
 Requires cookies to be enabled in your browser.

--- a/help/en-gb/article/article_category.textile
+++ b/help/en-gb/article/article_category.textile
@@ -2,7 +2,7 @@ h1. Articles: Categories
 
 Unlike sections, which define the navigational structure of a site, article categories allow organisation of articles by their subject matter. Once categories are assigned, lists of articles belonging to particular categories can be browsed.
 
-Likely article categories on a site about food might be:
+For example, likely article categories on a site about food might be:
 
 * raw ingredients
 * shopping

--- a/help/en-gb/article/article_image.textile
+++ b/help/en-gb/article/article_image.textile
@@ -3,7 +3,7 @@ h1. Articles: Article image
 If you would like to associate a single image with this article, place one of the following here:
 
 # a Textpattern image ID
-# a relative URL to the image (e.g. @/images/my_pic.jpg@)
-# a fully-qualified URL (e.g. @http://example.com/path/to/images/my_pic.jpg@)
+# a relative URL to the image (e.g., @/images/my_pic.jpg@)
+# a fully-qualified URL (e.g., @http://example.com/path/to/images/my_pic.jpg@)
 
 The image can be displayed by placing a @<txp:article_image />@ tag inside an article form. It will output a complete HTML @<img>@ tag to your chosen image.

--- a/help/en-gb/article/body.textile
+++ b/help/en-gb/article/body.textile
@@ -2,4 +2,4 @@ h1. Articles: Body
 
 The main content of an article is contained within the article body.
 
-When composing or readying articles for publication in Textpattern, you can switch between three views of the article: plain text, HTML (the code with which a web browser renders the article), and a rendered preview.
+When composing or preparing articles for publication in Textpattern, you can switch between three views of the article: plain text, HTML markup (the code with which a web browser renders the article), and a rendered preview.

--- a/help/en-gb/article/excerpt.textile
+++ b/help/en-gb/article/excerpt.textile
@@ -1,3 +1,3 @@
 h1. Articles: Excerpt
 
-Article excerpts are optional. Excerpts could be used as a short summary of the article that is displayed as part of a table of contents, or used in place of the full article body in the site's RSS/Atom feeds, or a number of other uses.
+Article excerpts are optional. Excerpts could be used as a short summary of the article that is displayed as part of a table of contents, used in place of the full article body in the site's RSS/Atom feeds, or a number of other uses.

--- a/help/en-gb/article/override_form.textile
+++ b/help/en-gb/article/override_form.textile
@@ -1,3 +1,3 @@
 h1. Articles: Override form
 
-If on occasion you wish for an article to use a form different from that assigned by default - for example if you want to show only an article excerpt with @<txp:excerpt />@ where you normally show the entire article with @<txp:body />@ - this can be set here.
+If you wish for an article to use a form different from that assigned by default - for example if you want to show only an article excerpt with @<txp:excerpt />@ where you normally show the entire article with @<txp:body />@ - this can be set here.

--- a/help/en-gb/article/timestamp.textile
+++ b/help/en-gb/article/timestamp.textile
@@ -7,4 +7,4 @@ The boxes correspond to the following information:
 Year / Month / Day
 Hour(24hr) : Minute : Second
 
-Content with timestamps greater than the current time (i.e. in the future) will not appear on the site until that time passes.
+Content with timestamps greater than the current time (i.e., in the future) will not appear on the site and the respective RSS/Atom feeds until that time passes.

--- a/help/en-gb/article/url_title.textile
+++ b/help/en-gb/article/url_title.textile
@@ -1,5 +1,5 @@
 h1. Articles: URL title
 
-If you would like to have a specific title attached to the permalink URL for your article, enter it here. If it is left blank, the URL title will be generated from the actual article title.
+If you would like to have a specific title attached to the permalink URL for your article, enter it here. If it is left blank, the URL title will be automatically generated from the actual article title.
 
 This is particularly useful if the title of your article uses non-ASCII characters.

--- a/help/en-gb/diag/clean_url_data_failed.textile
+++ b/help/en-gb/diag/clean_url_data_failed.textile
@@ -1,12 +1,12 @@
 h1. Diagnostics: Clean URL data failed
 
-It appears that either your site URLs (@example.com/section/article@) are currently not working or your server does not support the test procedure to determine if clean URLs work or not; if clean URLs on your site actually work, you can ignore this message.
+It appears that either your site URLs (@example.com/section/article@) are currently not working or your server does not support the test procedure to determine if clean URLs work or not; if clean URLs on your site work, you can safely ignore this message.
 
-If clean URLs are not working it may mean either:
+If clean URLs are _not_ working it may mean either:
 
-# your 'Site URL' setting is incorrect, or the page at that address is not managed by this copy of Textpattern
-# your server requires some changes to @.htaccess@ in order to make clean URLs work
-# your server doesn't support clean URLs at all
+# your 'Site URL' setting is incorrect, or the page at that address is not managed by this copy of Textpattern.
+# your server requires some changes to @.htaccess@ in order to make clean URLs work.
+# your server doesn't support clean URLs at all.
 
 The clean URL test attempts to fetch a page from the web address specified in the 'Site URL' preference in order to check that all clean URL parameters are working correctly. If that URL is a different site, or has been replaced with a static page or similar, the test will fail. Until the issue is resolved you will have to use messy URLs on your site instead (@example.com?s=section&id=4@). Ensure the 'Permanent link mode' in Admin Preferences is set accordingly.
 

--- a/help/en-gb/diag/clean_url_test_failed.textile
+++ b/help/en-gb/diag/clean_url_test_failed.textile
@@ -1,6 +1,6 @@
 h1. Diagnostics: Clean URL test failed
 
-It appears that either your site URLs (@example.com/section/article@) are currently not working or your server does not support the test procedure to determine if clean URLs work or not; if clean URLs on your site actually work, you can ignore this message.
+It appears that either your site URLs (@example.com/section/article@) are currently not working or your server does not support the test procedure to determine if clean URLs work or not; if clean URLs on your site work, you can safely ignore this message.
 
 If clean URLs are not working it may mean either:
 

--- a/help/en-gb/diag/cleanurl_only_apache.textile
+++ b/help/en-gb/diag/cleanurl_only_apache.textile
@@ -1,3 +1,3 @@
 h1. Diagnostics: Clean URL support
 
-Clean URLs are only supported on Apache. If you are using another server technology, use these at your own risk.
+Clean URLs are only supported on Apache. If you are using another server platform, use short URLs at your own risk.

--- a/help/en-gb/diag/dir_not_writable.textile
+++ b/help/en-gb/diag/dir_not_writable.textile
@@ -1,3 +1,3 @@
 h1. Diagnostics: Directory is not writable
 
-To use the file and image upload capabilities, these directories have to be writable by PHP. Usually this means you have to change permissions to *755*. This can be done with your FTP client, or alternatively on the command line by issuing a @chmod 755 /path/to/dir@ command.
+To use the file and image upload capabilities, these directories have to be writable by PHP. Usually this means you have to change permissions to @755@. This can be done with your FTP client, or alternatively on the command line by issuing a @chmod 755 /path/to/dir@ command.

--- a/help/en-gb/diag/dns_lookup_fails.textile
+++ b/help/en-gb/diag/dns_lookup_fails.textile
@@ -1,3 +1,3 @@
 h1. Diagnostics: DNS fails
 
-It appears the URI you specified as the address of your site is unreachable on the web.
+It appears the URL you specified as the address of your site is unreachable on the web.

--- a/help/en-gb/diag/htaccess_missing.textile
+++ b/help/en-gb/diag/htaccess_missing.textile
@@ -2,8 +2,13 @@ h1. Diagnostics: .htaccess file missing
 
 You are using a permanent link mode which requires an @.htaccess@ file to be placed in your site root directory. The recommended directives to place in this .htaccess file are:
 
-bc. RewriteEngine On
+bc. <IfModule mod_rewrite.c>
+RewriteEngine On
 RewriteCond %{REQUEST_FILENAME} -f [OR]
 RewriteCond %{REQUEST_FILENAME} -d
 RewriteRule ^(.+) - [PT,L]
+RewriteCond %{REQUEST_URI} !=/favicon.ico
 RewriteRule ^(.*) index.php
+RewriteCond %{HTTP:Authorization}  !^$
+RewriteRule .* - [E=REMOTE_USER:%{HTTP:Authorization}]
+</IfModule>

--- a/help/en-gb/diag/index_inaccessible.textile
+++ b/help/en-gb/diag/index_inaccessible.textile
@@ -1,3 +1,3 @@
 h1. Diagnostics: Site index inaccessible
 
-The main @index.php@ file specified as the index for your site is unreadable by the webserver. Please check permissions.
+The main @index.php@ file specified as the index for your site is unreadable by the server. Please check permissions.

--- a/help/en-gb/diag/mod_rewrite_missing.textile
+++ b/help/en-gb/diag/mod_rewrite_missing.textile
@@ -1,3 +1,3 @@
 h1. Diagnostics: Apache mod_rewrite missing
 
-Apache's module @mod_rewrite@ is not installed. This is required for Textpattern to function correctly. Please check your @.htaccess@ file is set up correctly, or contact your host for assistance.
+Apache's @mod_rewrite@ module is not installed, or installed but not enabled. This is required for Textpattern to function correctly. Please check your @.htaccess@ file is set up correctly, or contact your host for assistance.

--- a/help/en-gb/diag/modified_files.textile
+++ b/help/en-gb/diag/modified_files.textile
@@ -1,3 +1,3 @@
 h1. Diagnostics: Modified files
 
-If any files in the Textpattern installation are different to those expected, the files will be highlighted here. This is not necessarily a problem, but may be worth checking out if you are having problems with the functionality of your site.
+If any files in the Textpattern installation are different to those expected, the files will be highlighted here. This is not necessarily a problem, but may be worth checking out if you are having problems with the functionality of your site. Files are determined to be modified if their respective checksum differs from the known-good checksum list.

--- a/help/en-gb/diag/mysql_table_errors.textile
+++ b/help/en-gb/diag/mysql_table_errors.textile
@@ -1,3 +1,3 @@
 h1. Diagnostics: MySQL table errors
 
-Something is probably corrupt or otherwise damaged in your MySQL database. If you have access to phpMyAdmin, try repairing the offending table(s).
+Something is probably corrupt or otherwise damaged in your MySQL database. If you have access to a MySQL access tool, such as phpMyAdmin, try repairing the offending table(s).

--- a/help/en-gb/diag/no_temp_dir.textile
+++ b/help/en-gb/diag/no_temp_dir.textile
@@ -1,3 +1,3 @@
 h1. Diagnostics: No temp directory defined
 
-While Textpattern will run without a temporary directory, some parts may not work as expected if this preference is not set. Please visit Admin Preferences and set up the 'Temporary directory path'.
+While Textpattern will run without a temporary directory, some functionality may not work as expected if this preference is not set. Please visit Admin Preferences and set up the 'Temporary directory path'.

--- a/help/en-gb/diag/path_not_doc_root.textile
+++ b/help/en-gb/diag/path_not_doc_root.textile
@@ -1,3 +1,3 @@
 h1. Diagnostics: path_to_site does not match
 
-Two variables set by your webserver which should match, but do not.
+Two variables set by your web server which should match, but do not.

--- a/help/en-gb/diag/path_to_site_inacc.textile
+++ b/help/en-gb/diag/path_to_site_inacc.textile
@@ -1,3 +1,3 @@
 h1. Diagnostics: Site directory unreadable
 
-The directory containing the @index.php@ file specified as the index for your site is unreadable by the webserver. Please check permissions.
+The directory containing the @index.php@ file specified as the index for your site is unreadable by the server. Please check permissions.

--- a/help/en-gb/diag/php_version_required.textile
+++ b/help/en-gb/diag/php_version_required.textile
@@ -3,5 +3,13 @@ h1. Diagnostics: Minimum version requirements
 Textpattern requires certain functionality present in the PHP programming language and MySQL database. Please consult the following table to determine the minimum system requirements for the version of Textpattern you have downloaded:
 
 |_. Textpattern version |_. PHP version |_. MySQL version |
-| 4.5.x | 5.2 | 5 |
+| 4.5.x | 5.2.3 | 4.1 |
 | 4.0.1 - 4.4.1 | 4.3 | 3.23 |
+
+In addition to the above system requirements, the following PHP extensions are required:
+
+* "MySQL":http://www.php.net/manual/en/ref.mysql.php
+* "XML":http://www.php.net/manual/en/ref.xml.php
+* "JSON":http://www.php.net/manual/en/ref.json.php
+
+Your php.ini file, either global or local, should contain a @date.timezone@ setting.

--- a/help/en-gb/diag/setup_still_exists.textile
+++ b/help/en-gb/diag/setup_still_exists.textile
@@ -1,3 +1,3 @@
 h1. Diagnostics: /path/to/textpattern/setup still exists
 
-Once Textpattern has been installed, this directory is no longer needed and is recommended for deletion. You will continue to receive this warning until you have removed it, as this can potentially be a security concern.
+Once Textpattern has been installed, this directory is no longer needed and should be deleted. You will continue to receive this warning until you have removed it, as this can potentially be a security concern.

--- a/help/en-gb/diag/site_url_mismatch.textile
+++ b/help/en-gb/diag/site_url_mismatch.textile
@@ -2,6 +2,6 @@ h1. Diagnostics: Site URL mismatch
 
 The Site URL as set in the preferences tab does not match the actual URL you use to visit your website at this very moment.
 
-If your website can be reached through multiple different URLs, or if the links on your Textpattern powered website all function correctly, you can ignore this warning.
+If your website can be reached through multiple different URLs, or if the links on your Textpattern powered website all function correctly, you can safely ignore this warning.
 
 Otherwise, you are advised to correct the 'Site URL' setting in Admin Preferences. An educated guess of the correct Site URL is shown in the pre-flight warning message on the diagnostics tab.

--- a/help/en-gb/diag/some_php_functions_disabled.textile
+++ b/help/en-gb/diag/some_php_functions_disabled.textile
@@ -1,4 +1,4 @@
-h1. Diagnostics: The following PHP functions... are disabled on your server
+h1. Diagnostics: The following PHP functions: [...] are disabled on your server
 
 This means your hosting company or server administrator has disabled one or more PHP functions, some of which may affect the running of Textpattern.
 

--- a/help/en-gb/diag/textpattern_version_update.textile
+++ b/help/en-gb/diag/textpattern_version_update.textile
@@ -4,8 +4,8 @@ There is a newer version of Textpattern CMS available. To take advantage of the 
 
 Please note that while we strive to make the upgrade experience as seamless and pain-free as possible:
 
-* If only the last digit differs from your current version, the upgrade is likely to be backwards compatible with plugins and themes
-* If the last two digits differ from your current version, the upgrade might require updates to some plugins or themes, although it will probably continue to work anyway in a limited capacity
-* If the first digit is different from your current version, the upgrade is likely to require updates to most plugins and themes. If you rely heavily on a particular plugin or theme feature, please check with the author or community members before commencing the upgrade
+* If only the last digit differs from your current version, the upgrade is likely to be backwards compatible with plugins and themes.
+* If the last two digits differ from your current version, the upgrade might require updates to some plugins and/or themes, although it will probably continue to work anyway in a limited capacity.
+* If the first digit is different from your current version, the upgrade is likely to require updates to most plugins and themes. If you rely heavily on a particular plugin or theme feature, please check with the author or community members before commencing the upgrade.
 
 If the messages reads "There is a problem trying to connect to the RPC server" it means a new version could not be checked at this time (the server may be down). Updates are checked every 24 hours so it is likely that next time you visit the Diagnostics panel, all will be well.

--- a/help/en-gb/diag/tmp_plugin_paths_match.textile
+++ b/help/en-gb/diag/tmp_plugin_paths_match.textile
@@ -1,3 +1,3 @@
 h1. Diagnostics: Plugins and tmp dirs should not match
 
-You should not put plugins in the @tmp@ directory. It is a security risk and could also affect your site if the temporary directory is flushed. Please ensure that the @tmp@ directory path is different to the @plugin_cache@ path.
+Plugins should have their own directory and not share the @tmp@ directory. This is a potential security risk and may adversely affect your site if the temporary directory is flushed. Please ensure that the @tmp@ directory path is different to the @plugin_cache@ path.

--- a/help/en-gb/diag/warn_mail_unavailable.textile
+++ b/help/en-gb/diag/warn_mail_unavailable.textile
@@ -1,3 +1,3 @@
 h1. Diagnostics: Your PHP installation is missing the mail() function
 
-PHP's "mail":http://php.net/manual/en/function.mail.php function is disabled. Therefore Textpattern cannot send emails, and you will not be able to use some functions. For example you won't be able to receive email notifications for comments, and you won't be able to add other users (well, you can add them, but they won't receive the email with their password).
+PHP's "mail":http://php.net/manual/en/function.mail.php function is disabled. Therefore Textpattern cannot send emails, and some functionality will not be available. For example, email notifications for new comments will not be sent, and new users will not receive a welcome email. Users can still be added, however.

--- a/help/en-gb/diag/warn_register_globals_or_update.textile
+++ b/help/en-gb/diag/warn_register_globals_or_update.textile
@@ -2,8 +2,8 @@ h1. Diagnostics: Turn register_globals off or update to a newer PHP version
 
 A severe vulnerability was discovered in certain versions of PHP concerning the controversial legacy feature "registered globals":http://php.net/manual/en/security.globals.php. "The security advisory":http://www.hardened-php.net/advisory_202005.79.html says: "can lead to unexpected behaviour of PHP applications, which can lead to execution of remote PHP code in many situations".
 
-Vulnerable versions are PHP4-versions <= 4.4.0 and PHP5-versions <= 5.0.5. You should either update to newer versions or make sure that @register_globals@ is turned off. @register_globals@ has been deprecated as of PHP 5.3.0 and finally removed as of PHP 5.4.0.
+Vulnerable versions are PHP4-versions <= 4.4.0 and PHP5-versions <= 5.0.5. You should either update to newer versions or make sure that @register_globals@ is turned off. @register_globals@ was deprecated as of PHP 5.3.0 and removed as of PHP 5.4.0.
 
 You can turn off @register_globals@ in the @php.ini@ file. If you are in a hosted environment, you may have an option in your hosting control panel for it (ask your host). When running PHP as an Apache module, it is also possible to turn @register_globals@ off via Apache's @.htaccess@ configuration files. Uncomment the following line from your @.htaccess@ file:
 
-bc. php_value register_globals off
+bc. php_value register_globals 0

--- a/help/en-gb/file/file_reassign.textile
+++ b/help/en-gb/file/file_reassign.textile
@@ -1,3 +1,3 @@
 h1. Files: Reassign file
 
-When you upload a file in place of one that is labelled 'Missing', your chosen file is uploaded to the server and linked to the original file information in the database. This means the file name of the original file will remain, as will all other associated information such as download count and category. The file size will, however, reflect the new file.
+When you upload a file in place of one that is labelled 'Missing', your chosen file is uploaded to the server and linked to the original file information in the database. This means the file name of the original file will remain, as will all other associated information such as download count and category. The file size will, however, be updated to reflect the new file.

--- a/help/en-gb/form/forms_overview.textile
+++ b/help/en-gb/form/forms_overview.textile
@@ -22,4 +22,4 @@ You may also choose to employ a form to display repeated content, such as header
 
 bc. <txp:output_form form="your_form_name" />
 
-A form can be as long as you wish, for example for a footer might include headings, paragraphs, links, conditional tags, and other forms such as @ordinary_list@.
+A form can be up to 64KB in size. An example for a footer might include headings, paragraphs, links, conditional tags, and references to other forms such as @ordinary_list@.

--- a/help/en-gb/image/upload_thumbnail.textile
+++ b/help/en-gb/image/upload_thumbnail.textile
@@ -1,5 +1,5 @@
 h1. Images: Upload thumbnail
 
-Full-size images can be assigned their own thumbnails. These are useful for linking to and indexing full-size images.
+Full size images can be assigned their own thumbnails. These are useful for linking to - and the indexing of - full size images.
 
-A reference to the thumbnail is exactly the same as the reference to the full-size image, with the addition of @t@ to the filename. For example, to reference a thumbnail associated with a fullsize image stored at @/images/12.jpg@ you would use @/images/12t.jpg@.
+A reference to the thumbnail is exactly the same as the reference to the full size image, with @t@ appended to the file name. For example, to reference a thumbnail associated with a full size image stored at @/images/12.jpg@ you would use @/images/12t.jpg@.

--- a/help/en-gb/import/import.textile
+++ b/help/en-gb/import/import.textile
@@ -7,4 +7,4 @@ You can import your data into Textpattern CMS from the following publishing tool
 * WordPress (including custom prefixes for your databases, if you're using them)
 * b2
 
-If you choose to import from a file - that is, Movable Type or Blogger - you must place it in the @textpattern/include/import@ directory and name it @import.txt@.
+If you choose to import from a file exported from another content management system - that is, Movable Type or Blogger - you must place it in the @textpattern/include/import@ directory and name it @import.txt@.

--- a/help/en-gb/import/import_invite.textile
+++ b/help/en-gb/import/import_invite.textile
@@ -1,3 +1,3 @@
 h1. Import: Default comments invite
 
-Here you can set comments invite for the articles you're about to import.
+Here you can set the comments invite text for the articles you're about to import.

--- a/help/en-gb/plugin/install_plugin.textile
+++ b/help/en-gb/plugin/install_plugin.textile
@@ -1,5 +1,5 @@
 h1. Plugins: Install plugin
 
-Paste the Plugin text file here and click 'Upload' to begin installation. Any Plugin you upload with the same name as one you have previously installed will be overwritten with the uploaded version.
+Paste the plugin text file here and click 'Upload' to begin installation. Any plugin you upload with the same name as one you have previously installed will be overwritten with the uploaded version.
 
-The Plugin text you paste here is *not* the PHP code but a BASE64-encoded piece of text, usually with a short header containing Plugin information (such as plugin name, version and description, author name, etc).
+The plugin text you paste here is *not* the raw PHP code but Base64-encoded text, usually preceded by a header containing plugin information (such as plugin name, version and description, author name, etc).

--- a/help/en-gb/prefs/allow_article_php_scripting.textile
+++ b/help/en-gb/prefs/allow_article_php_scripting.textile
@@ -1,5 +1,5 @@
 h1. Preferences: Allow PHP in articles?
 
-When enabled, this setting will allow use of PHP within articles. The author must have sufficient privileges to do so (by default, *only* "Publishers":http://rpc.textpattern.com/help/?item=about_privileges and "Managing Editors":http://rpc.textpattern.com/help/?item=about_privileges can).
+When enabled, this setting will allow use of PHP within articles. The author must have sufficient privileges to do so (by default, only "Publishers":http://rpc.textpattern.com/help/?item=about_privileges and "Managing Editors":http://rpc.textpattern.com/help/?item=about_privileges can).
 
-PHP code must be both *without* opening and closing PHP tags, and enclosed within "@<txp:php>@ tags":http://www.textpattern.net/wiki/index.php?title=php.
+PHP code must be *without* opening and closing PHP tags, and also enclosed within "@<txp:php>@ tags":http://www.textpattern.net/wiki/index.php?title=php.

--- a/help/en-gb/prefs/allow_page_php_scripting.textile
+++ b/help/en-gb/prefs/allow_page_php_scripting.textile
@@ -2,4 +2,4 @@ h1. Preferences: Allow PHP in pages?
 
 When enabled, this setting allows PHP code within page and form templates.
 
-PHP code must be both *without* opening and closing PHP tags, and enclosed within "@<txp:php>@ tags":http://www.textpattern.net/wiki/index.php?title=php.
+PHP code must be without opening and closing PHP tags, and also enclosed within "@<txp:php>@ tags":http://www.textpattern.net/wiki/index.php?title=php.

--- a/help/en-gb/prefs/archive_dateformat.textile
+++ b/help/en-gb/prefs/archive_dateformat.textile
@@ -1,3 +1,3 @@
 h1. Preferences: Archive date format
 
-How dates will appear on articles in subsections of your site.
+How dates will appear on articles in sections of your site.

--- a/help/en-gb/prefs/attach_titles_to_permalinks.textile
+++ b/help/en-gb/prefs/attach_titles_to_permalinks.textile
@@ -1,5 +1,5 @@
 h1. Preferences: Attach titles to permalinks?
 
-This setting will attach a dirified version of your @article-title@ to your URL, it is either generated automatically or can be manually overriden in the 'Advanced options' when editing an article.
+This setting will attach a dirified version of the article title to the URL. It is either generated automatically or can be manually overriden in the 'Advanced options' when editing an article.
 
 The setting will only have an effect when you are using clean URLs. For certain languages this may result in long and ugly URLs, in which case you probably want to set this to 'Off'.

--- a/help/en-gb/prefs/auto_dst.textile
+++ b/help/en-gb/prefs/auto_dst.textile
@@ -1,3 +1,3 @@
 h1. Preferences: Automatically adjust DST setting?
 
-If your server is running PHP 5.1+ this option will be available. It allows Textpattern to alter when DST(Daylight Savings Time) occurs in your locale. If this is set to 'No', you will be able to change the 'DST enabled' preference manually.
+This setting allows Textpattern to alter when DST(Daylight Savings Time) occurs in your locale. If this is set to 'No', you will be able to change the 'DST enabled' preference manually.

--- a/help/en-gb/prefs/comment_means_site_updated.textile
+++ b/help/en-gb/prefs/comment_means_site_updated.textile
@@ -1,3 +1,3 @@
 h1. Preferences: New comment means site updated?
 
-The Textpattern CMS database keeps track of when the last change to your site took place. When this setting is set to 'Yes', a new comment will also update this value. This value is used for example for @"Send Last-Modified header"@ functionality.
+The Textpattern database keeps track of when the last change to your site took place. When this setting is set to 'Yes', a new comment will also update this value. This value is used for example for @"Send Last-Modified header"@ functionality.

--- a/help/en-gb/prefs/comments_auto_append.textile
+++ b/help/en-gb/prefs/comments_auto_append.textile
@@ -2,6 +2,6 @@ h1. Preferences: Automatically append comments to articles?
 
 This setting determines whether comments and the comment form are automatically appended to all individual articles (by automatically including the contents of the "@comments_display@ form":http://www.textpattern.net/wiki/index.php?title=Default_Forms).
 
-The majority of the time, you will want this setting left 'No', as this allows greater flexibility to the positioning of your comments in your site design. You will need to add the "@<txp:comments />@ tag":http://www.textpattern.net/wiki/index.php?title=comments manually in any article-based templates where you want comments to appear.
+The majority of the time, you will want this set to 'No', as this allows greater flexibility to the positioning of your comments in your site design. You will need to add the "@<txp:comments />@ tag":http://www.textpattern.net/wiki/index.php?title=comments manually in any article-based templates where you want comments to appear.
 
 If you are experiencing duplicate display of comments in an article, then chances are your templates have the @<txp:comments />@ tag in a template but also have 'Automatically append comments to articles?' set to 'Yes' too - see "the related FAQ entry":http://textpattern.com/faq/95/comment-display-confusion for more information.

--- a/help/en-gb/prefs/comments_default_invite.textile
+++ b/help/en-gb/prefs/comments_default_invite.textile
@@ -7,4 +7,4 @@ If you allow visitors to comment on your site, this is the default invitation to
 * Feedback
 * Annotate
 
-Note that the invitation can always be changed on a per-article basis.
+Note that the invitation text can always be changed on a per-article basis.

--- a/help/en-gb/prefs/comments_mode.textile
+++ b/help/en-gb/prefs/comments_mode.textile
@@ -2,4 +2,4 @@ h1. Preferences: Comments mode
 
 If 'No popup' is selected (default, recommended) the current window will be refreshed to display only the current article, with comments beneath.
 
-If 'Popup' is selected, a new smaller browser window will open when the comments link is clicked (this uses the "@popup_comments@ 'Form' template":http://www.textpattern.net/wiki/index.php?title=Default_Forms).
+If 'Popup' is selected, a new browser window will open when the comments link is clicked (this uses the "@popup_comments@ 'Form' template":http://www.textpattern.net/wiki/index.php?title=Default_Forms).

--- a/help/en-gb/prefs/comments_on_default.textile
+++ b/help/en-gb/prefs/comments_on_default.textile
@@ -1,5 +1,5 @@
 h1. Preferences: Comments on by default?
 
-If this is set to 'Yes', comments will be automatically allowed for every article published. If set to 'No', you must click enable comments on the article 'Write' tab each time you want to accept comments.
+If this is set to 'Yes', comments will be automatically allowed for every article published. If set to 'No', you must enable comments on the article 'Write' tab each time you want to accept comments.
 
 Note that allowing comments can be turned on or off at any time, on a per-article basis.

--- a/help/en-gb/prefs/comments_require_name.textile
+++ b/help/en-gb/prefs/comments_require_name.textile
@@ -1,3 +1,3 @@
 h1. Preferences: Require user's name?
 
-If set to 'Yes', people that want to comment on your article will have to enter a name in the comment input form (they will not be able to post a comment if they do not supply a name).
+If set to 'Yes', people that want to comment on your article will have to enter a name in the comment input form. They will not be able to submit a comment if they do not supply a name.

--- a/help/en-gb/prefs/comments_use_fat_textile.textile
+++ b/help/en-gb/prefs/comments_use_fat_textile.textile
@@ -1,6 +1,6 @@
 h1. Preferences: Allow more Textile markup in comments?
 
-When set to 'Yes', comments may contain "Textile elements":http://textpattern.com/textile-sandbox which would otherwise be treated as plain text, such as:
+When set to 'Yes', comments may contain "Textile":http://textpattern.com/textile-sandbox elements which would otherwise be treated as plain text, such as:
 
 * headings
 * ordered and unordered lists

--- a/help/en-gb/prefs/default_event.textile
+++ b/help/en-gb/prefs/default_event.textile
@@ -1,3 +1,3 @@
 h1. Preferences: Default admin tab
 
-The Textpattern CMS admin interface tab that will appear first when anybody logs in.
+The Textpattern admin interface tab that will appear first when anybody logs in.

--- a/help/en-gb/prefs/enable_xmlrpc_server.textile
+++ b/help/en-gb/prefs/enable_xmlrpc_server.textile
@@ -1,3 +1,3 @@
 h1. Preferences: Enable XML-RPC server?
 
-If you wish to use "XML-RPC":http://www.xmlrpc.com/ for controlling Textpattern CMS content from remote places (e.g., desktop or mobile apps) you must switch the XML-RPC server on by setting this to 'Yes'.
+If you wish to use "XML-RPC":http://en.wikipedia.org/wiki/XML-RPC for controlling Textpattern content from remote places (e.g., desktop or mobile apps) you must switch the XML-RPC server on by setting this to 'Yes'.

--- a/help/en-gb/prefs/is_dst.textile
+++ b/help/en-gb/prefs/is_dst.textile
@@ -1,3 +1,3 @@
 h1. Preferences: DST enabled?
 
-Whether DST(Daylight Saving Time) is currently active for your time zone.
+Whether DST(Daylight Saving Time) is currently enabled for your time zone.

--- a/help/en-gb/prefs/lastmod_keepalive.textile
+++ b/help/en-gb/prefs/lastmod_keepalive.textile
@@ -1,3 +1,3 @@
 h1. Preferences: Compensate for persistent connection mod_deflate bug?
 
-Some @mod_deflate@ versions have a bug that breaks subsequent requests when keep-alive is used. Dropping the connection is the only reliable way to fix this. Setting this preference to 'Yes' will close the connection, forcing the browser to reconnect for the next request.
+Some @mod_deflate@ versions have a bug that breaks subsequent requests when @Keep Alive@ is used. Dropping the connection is the only reliable way to fix this. Setting this preference to 'Yes' will close the connection, forcing the browser to reconnect for the next request.

--- a/help/en-gb/prefs/override_emailcharset.textile
+++ b/help/en-gb/prefs/override_emailcharset.textile
@@ -1,5 +1,5 @@
 h1. Preferences: Use ISO-8859-1 encoding in emails (default is UTF-8)?
 
-The Textpattern CMS uses UTF-8 wherever possible as default, including for outgoing emails. However some older email clients (like some versions of Outlook) do not have proper UTF-8 support. If you see garbled characters in emails, this setting will try to convert mails to ISO-8859-1 before sending them.
+Textpattern uses UTF-8 encoding wherever possible as default, including for outgoing emails. However some older email clients (like some versions of Outlook) do not have proper UTF-8 support. If you see garbled characters in emails, this setting will try to convert mails to ISO-8859-1 before sending them.
 
-p(alert-block information). *Note:* If you are using a language the characters of which cannot be represented in ISO-8859-1, this setting will unfortunately not help you. You should try finding a UTF-8 (or unicode) compatible email client.
+p(alert-block information). *Note:* If you are using a language the characters of which cannot be represented in ISO-8859-1, this setting will unfortunately not help you. You should try finding a UTF-8 (or Unicode) compatible email client.

--- a/help/en-gb/prefs/permlink_mode.textile
+++ b/help/en-gb/prefs/permlink_mode.textile
@@ -6,4 +6,4 @@ This defines the method by which individual articles are reached via the URL dis
 
 bc. http://example.com/index.php?id=123
 
-All other modes require the 'mod_rewrite' Apache module to be installed on your server. If your server does not support that then either contact your web host or use the '?=messy' mode outlined above.
+All other modes require the @mod_rewrite@ Apache module to be installed and enabled on your server. If your server does not support @mod_rewrite@ either contact your web host or use the '?=messy' mode outlined above.

--- a/help/en-gb/prefs/plugin_cache_dir.textile
+++ b/help/en-gb/prefs/plugin_cache_dir.textile
@@ -1,6 +1,6 @@
 h1. Preferences: Plugin cache directory path
 
-This setting is mainly used for plugin developers. When specified, you can put the plugin source file (not compiled) in this directory and the Textpattern CMS will load it automatically, so you can easily edit the plugin and immediately see the effect it has without having to install/activate the plugin. *Beware* though that by using this method, a broken plugin (which fails to compile) will also break Textpattern!
+This setting is mainly used for plugin developers. When specified, you can put the plugin source file (not compiled) in this directory and Textpattern will load it automatically, so you can easily edit the plugin and immediately see the effect it has without having to install/activate the plugin. *Beware* though that by using this method, a broken plugin (which fails to compile) may also break Textpattern!
 
 It is recommended that you load plugins through the standard plugin admin page on a production site, rather than using the plugin cache directory.
 

--- a/help/en-gb/prefs/send_lastmod.textile
+++ b/help/en-gb/prefs/send_lastmod.textile
@@ -2,4 +2,4 @@ h1. Preferences: Send "Last-Modified" Header?
 
 When set, Textpattern will read a visitor's HTTP @If-Modified-Since@ header (if one exists) and compare it to the last site update. If nothing has changed since the visitor last loaded the page (i.e., if the timestamp the browser sends is the same as the last site update), then a header is sent back instructing the visitor's browser to use its cached version of the page.
 
-This can reduce bandwidth consumption, page load times, and reduce the load on the webserver.
+This can reduce bandwidth consumption, page load times, and reduce the load on the web server.

--- a/help/en-gb/prefs/show_comment_count_in_feed.textile
+++ b/help/en-gb/prefs/show_comment_count_in_feed.textile
@@ -1,3 +1,3 @@
 h1. Preferences: Show comment count in feeds?
 
-When set to 'Yes', this setting will append the number of comments to your article titles in XML feeds.
+When set to 'Yes', this setting will append the number of comments to your article titles in RSS/Atom feeds.

--- a/help/en-gb/prefs/site_slogan.textile
+++ b/help/en-gb/prefs/site_slogan.textile
@@ -1,3 +1,3 @@
 h1. Preferences: Site slogan
 
-The "site slogan":http://www.textpattern.net/wiki/index.php?title=site_slogan is a brief (maximum of 255 characters) summary or description of your site. It will be used as the description of your site wherever required, such as in your XML feeds, and may be used at any number of places throughout your site, at your discretion.
+The "site slogan":http://www.textpattern.net/wiki/index.php?title=site_slogan is a summary or description of your site. It will be used as the description of your site wherever required, such as in your RSS/Atom feeds, and may be used at any number of places throughout your site, at your discretion.

--- a/help/en-gb/prefs/smtp_from.textile
+++ b/help/en-gb/prefs/smtp_from.textile
@@ -4,7 +4,7 @@ This preference should be left blank unless you experience problems with sending
 
 For those interested in the technical details:
 
-* On UNIX/Mac servers, the entered email address is used as the 4th parameter (prefixed with "-f") for the PHP @mail()@ function
+* On UNIX/Mac OS servers, the entered email address is used as the 4th parameter (prefixed with "-f") for the PHP @mail()@ function
 * On Windows servers, the entered email address is used to set (or override) the @sendmail_from@ php.ini setting
 
 This ensures that the SMTP envelope sender address (which is not necessarily the same as the "From:" header you normally see in emails) is set to the email address you've entered here, which is a requirement for sending email on some web servers.

--- a/help/en-gb/prefs/spam_blacklists.textile
+++ b/help/en-gb/prefs/spam_blacklists.textile
@@ -1,5 +1,5 @@
 h1. Preferences: Spam blocklists (comma-separated)
 
-The "blocklist":http://en.wikipedia.org/wiki/Blacklist providers entered here will be contacted when a comment is posted to your blog, and the IP address of the comment poster will be checked. If the IP address is listed it means there has been one or more spamming complaints made about this IP in the past, and the comment will be rejected.
+The "blocklist":http://en.wikipedia.org/wiki/Blacklist providers entered here will be queried when a comment is posted to your blog, and the IP address of the comment poster will be checked. If the IP address is listed it means there has been one or more spamming complaints made about this IP in the past, and the comment will be rejected.
 
 You can enter a list of domain names here, seperated by commas. Potential blocklists can be found via "dmoz":http://www.dmoz.org/Computers/Internet/E-mail/Spam/Blacklists/List_of_Major_Blacklists/, but be aware that it is *your* responsibility to make sure you can trust those blocklist providers before you add any.

--- a/help/en-gb/prefs/syndicate_body_or_excerpt.textile
+++ b/help/en-gb/prefs/syndicate_body_or_excerpt.textile
@@ -1,3 +1,5 @@
 h1. Preferences: Syndicate article excerpt only?
 
-If this is set to 'No', then feeds will always contain the full article bodies. If set to 'Yes', feed items will contain an excerpt instead of the article body where it is available.
+If this is set to 'No', then feeds will always contain the full article bodies.
+
+If this is set to 'Yes', feed items will contain the article excerpt instead of the article body where it is available.

--- a/help/en-gb/prefs/tempdir.textile
+++ b/help/en-gb/prefs/tempdir.textile
@@ -1,5 +1,5 @@
 h1. Preferences: Temporary directory path
 
-Sets an *absolute path* to a temporary (sometimes know as 'tmp') directory. PHP needs to have write access to this directory. This folder is used for temporary scratch files, for example uploads of any kind (plugins, files or images).
+Sets an *absolute path* to a temporary (sometimes know as 'tmp') directory. PHP needs to have write access to this directory. This directory is used for temporary files, for example uploads of any kind (plugins, files or images).
 
 p(alert-block information). *Note:* Do not specify the same directory for both 'tmp' and 'plugin cache', as this will cause problems (Textpattern would try to run the contents of temporary log files as plugins).

--- a/help/en-gb/prefs/theme_name.textile
+++ b/help/en-gb/prefs/theme_name.textile
@@ -1,3 +1,3 @@
 h1. Preferences: Admin-side theme
 
-The default admin-side theme that will be used when anybody logs into Textpattern. The system ships with a number of pre-built admin themes, and you can also add custom theme packages to the @textpattern/theme@ folder to make them available for selection.
+The default admin-side theme that will be used when anybody logs into Textpattern. Textpattern ships with a number of pre-installed admin themes, and you can also add custom theme packages to the @textpattern/theme@ directory to make them available for selection.

--- a/help/en-gb/prefs/use_comments.textile
+++ b/help/en-gb/prefs/use_comments.textile
@@ -1,3 +1,3 @@
 h1. Preferences: Accept comments?
 
-This sets whether Textpattern's commenting features should be visible or completely turned off.
+This sets whether Textpattern's commenting features should be enabled or disabled.

--- a/help/en-gb/prefs/use_dns.textile
+++ b/help/en-gb/prefs/use_dns.textile
@@ -1,3 +1,3 @@
 h1. Preferences: Use DNS?
 
-This setting only has an effect when 'Logging' is turned on. Using DNS will allow you to translate IP addresses in your logs to hostnames. For some servers this might subjectively slow down your site, in which case you might want to set this to 'No'.
+This setting only has an effect when 'Logging' is turned on. Using DNS will, where possible, translate IP addresses in your logs to hostnames. In some instances this might slow down your site, in which case you might want to set this to 'No'.

--- a/help/en-gb/section/section_category.textile
+++ b/help/en-gb/section/section_category.textile
@@ -1,6 +1,6 @@
 h1. Sections: Introduction
 
-Sections in Textpattern are perhaps best thought of as analogous to sections in a newspaper: each belong to the same publication, but each might feature a different layout, or a different style of article, and so on.
+Sections in Textpattern are perhaps best thought of as analogous to sections in a newspaper; each belong to the same publication, but each might feature a different layout, or a different style of article, and so on.
 
 For most websites, only a bare minimum of sections need be created.
 
@@ -10,4 +10,4 @@ For most websites, only a bare minimum of sections need be created.
 # *About:* An 'about this site' page, which differs from the front page and the "Archive" section, in that it is more static, may have a different layout, and will likely contain only one article. The "About" section would be reached at @http://example.com/about/@.
 # *Photos:* A 'Section' whose differing layout (and possibly different CSS) would display photos instead of articles.
 
-Note that a special hidden section always exists, named default. Using the page called default and the style called default, this is what makes up the front page of your site.
+Note that a special hidden section, named default, always exists. This default section uses the page named default and the style called default, and it constructs the front page of your site.

--- a/help/en-gb/section/section_default.textile
+++ b/help/en-gb/section/section_default.textile
@@ -1,7 +1,7 @@
 h1. Sections: Default publishing section
 
-This option governs which section will be preselected in the Section menu when creating a new article on the Write tab.
+This option governs which section will be pre-selected in the Section menu when creating a new article on the Write tab.
 
 If most of your articles end up belonging to a particular section, select it from the list here. Changes will be reflected immediately.
 
-You can be override this per article in the Write tab by selecting a different section in the 'Sort and display' pane.
+You can override this per article in the Write tab by selecting a different section in the 'Sort and display' pane.

--- a/help/en-gb/section/section_syndicate.textile
+++ b/help/en-gb/section/section_syndicate.textile
@@ -1,3 +1,3 @@
 h1. Sections: Syndicate articles in this section?
 
-Governs whether or not articles in this section will appear in the site's RSS and Atom XML feeds.
+Governs whether or not articles in this section will appear in the site's RSS and Atom feeds.

--- a/help/en-gb/setup/setup_user_pass.textile
+++ b/help/en-gb/setup/setup_user_pass.textile
@@ -8,5 +8,5 @@ h3. Tips
 * Use numbers
 * Use symbols
 * Make it at least eight characters in length
-* *Avoid* any personal information (dates, names, places, etc.)
+* *Avoid* any personal information (dates, names, places, family members, pets etc.)
 * *Avoid* any sole or repeated dictionary words, regardless of spelling, language or case

--- a/help/en-gb/textfilter/textile/abbreviation.textile
+++ b/help/en-gb/textfilter/textile/abbreviation.textile
@@ -22,7 +22,7 @@ h3. Textile documentation
 
 "More information on abbreviations in Textile":http://textpattern.com/textile-abbr.
 
-h3. HTML documentation (via MDN)
+h3. HTML documentation (via Mozilla Developer Network)
 
 "The @<abbr>@ HTML element":https://developer.mozilla.org/en-US/docs/Web/HTML/Element/abbr.
 

--- a/help/en-gb/textfilter/textile/blockquote.textile
+++ b/help/en-gb/textfilter/textile/blockquote.textile
@@ -28,6 +28,6 @@ h3. Textile documentation
 
 "More information on block quotations in Textile":http://textpattern.com/textile-blockquote.
 
-h3. HTML documentation (via MDN)
+h3. HTML documentation (via Mozilla Developer Network)
 
 "The @<blockquote>@ HTML element":https://developer.mozilla.org/en-US/docs/Web/HTML/Element/blockquote.

--- a/help/en-gb/textfilter/textile/bold.textile
+++ b/help/en-gb/textfilter/textile/bold.textile
@@ -16,7 +16,7 @@ h3. Textile documentation
 
 "More information on strong and bold text in Textile":http://textpattern.com/textile-strong-and-b.
 
-h3. HTML documentation (via MDN)
+h3. HTML documentation (via Mozilla Developer Network)
 
 "The @<strong>@ HTML element":https://developer.mozilla.org/en-US/docs/Web/HTML/Element/strong.
 

--- a/help/en-gb/textfilter/textile/cite.textile
+++ b/help/en-gb/textfilter/textile/cite.textile
@@ -12,6 +12,6 @@ h3. Textile documentation
 
 "More information on citation in Textile":http://textpattern.com/textile-cite.
 
-h3. HTML documentation (via MDN)
+h3. HTML documentation (via Mozilla Developer Network)
 
 "The @<cite>@ HTML element":https://developer.mozilla.org/en-US/docs/Web/HTML/Element/cite.

--- a/help/en-gb/textfilter/textile/definition.textile
+++ b/help/en-gb/textfilter/textile/definition.textile
@@ -64,7 +64,7 @@ h3. Textile documentation
 
 "More information on definition lists in Textile":http://textpattern.com/textile-dl-list.
 
-h3. HTML documentation (via MDN)
+h3. HTML documentation (via Mozilla Developer Network)
 
 "The @<dl>@ HTML element":https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dl.
 

--- a/help/en-gb/textfilter/textile/delete.textile
+++ b/help/en-gb/textfilter/textile/delete.textile
@@ -12,6 +12,6 @@ h3. Textile documentation
 
 "More information on insertions and deletions in Textile":http://textpattern.com/textile-ins-and-del.
 
-h3. HTML documentation (via MDN)
+h3. HTML documentation (via Mozilla Developer Network)
 
 "The @<del>@ HTML element":https://developer.mozilla.org/en-US/docs/Web/HTML/Element/del.

--- a/help/en-gb/textfilter/textile/footnote.textile
+++ b/help/en-gb/textfilter/textile/footnote.textile
@@ -30,6 +30,6 @@ h3. Textile documentation
 
 "More information on footnotes in Textile":http://textpattern.com/textile-footnote.
 
-h3. HTML documentation (via MDN)
+h3. HTML documentation (via Mozilla Developer Network)
 
 "The @<sup>@ HTML element":https://developer.mozilla.org/en-US/docs/Web/HTML/Element/sup.

--- a/help/en-gb/textfilter/textile/heading.textile
+++ b/help/en-gb/textfilter/textile/heading.textile
@@ -32,6 +32,6 @@ h3. Textile documentation
 
 "More information on headings in Textile":http://textpattern.com/textile-heading.
 
-h3. HTML documentation (via MDN)
+h3. HTML documentation (via Mozilla Developer Network)
 
 "The @h1@ - @h6@ HTML elements":https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements.

--- a/help/en-gb/textfilter/textile/image.textile
+++ b/help/en-gb/textfilter/textile/image.textile
@@ -34,7 +34,7 @@ h3. Textile documentation
 
 "More information on images in Textile":http://textpattern.com/textile-image.
 
-h3. HTML documentation (via MDN)
+h3. HTML documentation (via Mozilla Developer Network)
 
 "The @<img>@ HTML element":https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img.
 

--- a/help/en-gb/textfilter/textile/insert.textile
+++ b/help/en-gb/textfilter/textile/insert.textile
@@ -12,6 +12,6 @@ h3. Textile documentation
 
 "More information on insertions and deletions in Textile":http://textpattern.com/textile-ins-and-del.
 
-h3. HTML documentation (via MDN)
+h3. HTML documentation (via Mozilla Developer Network)
 
 "The @<ins>@ HTML element":https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ins.

--- a/help/en-gb/textfilter/textile/italic.textile
+++ b/help/en-gb/textfilter/textile/italic.textile
@@ -16,7 +16,7 @@ h3. Textile documentation
 
 "More information on emphasised and italic text in Textile":http://textpattern.com/textile-em-and-i.
 
-h3. HTML documentation (via MDN)
+h3. HTML documentation (via Mozilla Developer Network)
 
 "The @<em>@ HTML element":https://developer.mozilla.org/en-US/docs/Web/HTML/Element/em.
 

--- a/help/en-gb/textfilter/textile/link.textile
+++ b/help/en-gb/textfilter/textile/link.textile
@@ -38,6 +38,6 @@ h3. Textile documentation
 
 "More information on links in Textile":http://textpattern.com/textile-link.
 
-h3. HTML documentation (via MDN)
+h3. HTML documentation (via Mozilla Developer Network)
 
 "The @<a>@ HTML element":https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a.

--- a/help/en-gb/textfilter/textile/list-bulleted.textile
+++ b/help/en-gb/textfilter/textile/list-bulleted.textile
@@ -40,7 +40,7 @@ h3. Textile documentation
 
 "More information on bulleted lists in Textile":http://textpattern.com/textile-ul-list.
 
-h3. HTML documentation (via MDN)
+h3. HTML documentation (via Mozilla Developer Network)
 
 "The @<ul>@ HTML element":https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ul.
 

--- a/help/en-gb/textfilter/textile/list-numerical.textile
+++ b/help/en-gb/textfilter/textile/list-numerical.textile
@@ -40,7 +40,7 @@ h3. Textile documentation
 
 "More information on numerical lists in Textile":http://textpattern.com/textile-ol-list.
 
-h3. HTML documentation (via MDN)
+h3. HTML documentation (via Mozilla Developer Network)
 
 "The @<ol>@ HTML element":https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ol.
 

--- a/help/en-gb/textfilter/textile/span.textile
+++ b/help/en-gb/textfilter/textile/span.textile
@@ -14,6 +14,6 @@ h3. Textile documentation
 
 "More information on spans in Textile":http://textpattern.com/textile-span.
 
-h3. HTML documentation (via MDN)
+h3. HTML documentation (via Mozilla Developer Network)
 
 "The @<span>@ HTML element":https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span.

--- a/help/en-gb/textfilter/textile/subscript.textile
+++ b/help/en-gb/textfilter/textile/subscript.textile
@@ -12,6 +12,6 @@ h3. Textile documentation
 
 "More information on superscript and subscript text in Textile":http://textpattern.com/textile-sub-and-sup.
 
-h3. HTML documentation (via MDN)
+h3. HTML documentation (via Mozilla Developer Network)
 
 "The @<sub>@ HTML element":https://developer.mozilla.org/en-US/docs/Web/HTML/Element/sub.

--- a/help/en-gb/textfilter/textile/superscript.textile
+++ b/help/en-gb/textfilter/textile/superscript.textile
@@ -12,6 +12,6 @@ h3. Textile documentation
 
 "More information on superscript and subscript text in Textile":http://textpattern.com/textile-sub-and-sup.
 
-h3. HTML documentation (via MDN)
+h3. HTML documentation (via Mozilla Developer Network)
 
 "The @<sup>@ HTML element":https://developer.mozilla.org/en-US/docs/Web/HTML/Element/sup.

--- a/help/en-gb/textfilter/textile/table.textile
+++ b/help/en-gb/textfilter/textile/table.textile
@@ -46,7 +46,7 @@ h3. Textile documentation
 
 "More information on tables in Textile":http://textpattern.com/textile-table.
 
-h3. HTML documentation (via MDN)
+h3. HTML documentation (via Mozilla Developer Network)
 
 "The @<table>@ HTML element":https://developer.mozilla.org/en-US/docs/Web/HTML/Element/table.
 


### PR DESCRIPTION
Supersedes the self-closed PR here: https://github.com/textpattern/pophelp/pull/6

Corrects 2x typos spotted by @Bloke, and includes some more uniformity tidying - e.g., `folder` to `directory`.
